### PR TITLE
Morph: migrate yaml key using openai gpt 4.1-mini

### DIFF
--- a/src/main/resources/yaml_change_value/large_10_actual.yaml
+++ b/src/main/resources/yaml_change_value/large_10_actual.yaml
@@ -121,11 +121,11 @@ spec:
 
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           #            requests:
           #              cpu: "100m"
           #              memory: "256Mi"

--- a/src/main/resources/yaml_change_value/large_1_actual.yaml
+++ b/src/main/resources/yaml_change_value/large_1_actual.yaml
@@ -121,11 +121,11 @@ spec:
 
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           #            requests:
           #              cpu: "100m"
           #              memory: "256Mi"

--- a/src/main/resources/yaml_change_value/large_2_actual.yaml
+++ b/src/main/resources/yaml_change_value/large_2_actual.yaml
@@ -121,11 +121,11 @@ spec:
 
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           #            requests:
           #              cpu: "100m"
           #              memory: "256Mi"

--- a/src/main/resources/yaml_change_value/large_3_actual.yaml
+++ b/src/main/resources/yaml_change_value/large_3_actual.yaml
@@ -121,11 +121,11 @@ spec:
 
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           #            requests:
           #              cpu: "100m"
           #              memory: "256Mi"

--- a/src/main/resources/yaml_change_value/large_4_actual.yaml
+++ b/src/main/resources/yaml_change_value/large_4_actual.yaml
@@ -121,11 +121,11 @@ spec:
 
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           #            requests:
           #              cpu: "100m"
           #              memory: "256Mi"

--- a/src/main/resources/yaml_change_value/large_5_actual.yaml
+++ b/src/main/resources/yaml_change_value/large_5_actual.yaml
@@ -121,11 +121,11 @@ spec:
 
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           #            requests:
           #              cpu: "100m"
           #              memory: "256Mi"

--- a/src/main/resources/yaml_change_value/large_7_actual.yaml
+++ b/src/main/resources/yaml_change_value/large_7_actual.yaml
@@ -121,11 +121,11 @@ spec:
 
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           #            requests:
           #              cpu: "100m"
           #              memory: "256Mi"

--- a/src/main/resources/yaml_change_value/large_8_actual.yaml
+++ b/src/main/resources/yaml_change_value/large_8_actual.yaml
@@ -121,11 +121,11 @@ spec:
 
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           #            requests:
           #              cpu: "100m"
           #              memory: "256Mi"

--- a/src/main/resources/yaml_change_value/large_9_actual.yaml
+++ b/src/main/resources/yaml_change_value/large_9_actual.yaml
@@ -121,11 +121,11 @@ spec:
 
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           #            requests:
           #              cpu: "100m"
           #              memory: "256Mi"

--- a/src/main/resources/yaml_change_value/simple_10_actual.yaml
+++ b/src/main/resources/yaml_change_value/simple_10_actual.yaml
@@ -29,11 +29,11 @@ spec:
                   key: api-url
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           readinessProbe:
             httpGet:
               path: /healthz

--- a/src/main/resources/yaml_change_value/simple_1_actual.yaml
+++ b/src/main/resources/yaml_change_value/simple_1_actual.yaml
@@ -29,11 +29,11 @@ spec:
                   key: api-url
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           readinessProbe:
             httpGet:
               path: /healthz

--- a/src/main/resources/yaml_change_value/simple_2_actual.yaml
+++ b/src/main/resources/yaml_change_value/simple_2_actual.yaml
@@ -29,11 +29,11 @@ spec:
                   key: api-url
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           readinessProbe:
             httpGet:
               path: /healthz

--- a/src/main/resources/yaml_change_value/simple_3_actual.yaml
+++ b/src/main/resources/yaml_change_value/simple_3_actual.yaml
@@ -29,11 +29,11 @@ spec:
                   key: api-url
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           readinessProbe:
             httpGet:
               path: /healthz

--- a/src/main/resources/yaml_change_value/simple_4_actual.yaml
+++ b/src/main/resources/yaml_change_value/simple_4_actual.yaml
@@ -29,11 +29,11 @@ spec:
                   key: api-url
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           readinessProbe:
             httpGet:
               path: /healthz

--- a/src/main/resources/yaml_change_value/simple_5_actual.yaml
+++ b/src/main/resources/yaml_change_value/simple_5_actual.yaml
@@ -29,11 +29,11 @@ spec:
                   key: api-url
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           readinessProbe:
             httpGet:
               path: /healthz

--- a/src/main/resources/yaml_change_value/simple_6_actual.yaml
+++ b/src/main/resources/yaml_change_value/simple_6_actual.yaml
@@ -29,11 +29,11 @@ spec:
                   key: api-url
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           readinessProbe:
             httpGet:
               path: /healthz

--- a/src/main/resources/yaml_change_value/simple_7_actual.yaml
+++ b/src/main/resources/yaml_change_value/simple_7_actual.yaml
@@ -29,11 +29,11 @@ spec:
                   key: api-url
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           readinessProbe:
             httpGet:
               path: /healthz

--- a/src/main/resources/yaml_change_value/simple_8_actual.yaml
+++ b/src/main/resources/yaml_change_value/simple_8_actual.yaml
@@ -29,11 +29,11 @@ spec:
                   key: api-url
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           readinessProbe:
             httpGet:
               path: /healthz

--- a/src/main/resources/yaml_change_value/simple_9_actual.yaml
+++ b/src/main/resources/yaml_change_value/simple_9_actual.yaml
@@ -29,11 +29,11 @@ spec:
                   key: api-url
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           readinessProbe:
             httpGet:
               path: /healthz

--- a/src/main/resources/yaml_change_value/with_comments_10_actual.yaml
+++ b/src/main/resources/yaml_change_value/with_comments_10_actual.yaml
@@ -52,11 +52,11 @@ spec:
 
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           #            requests:
           #              cpu: "100m"
           #              memory: "256Mi"

--- a/src/main/resources/yaml_change_value/with_comments_1_actual.yaml
+++ b/src/main/resources/yaml_change_value/with_comments_1_actual.yaml
@@ -52,11 +52,11 @@ spec:
 
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           #            requests:
           #              cpu: "100m"
           #              memory: "256Mi"

--- a/src/main/resources/yaml_change_value/with_comments_2_actual.yaml
+++ b/src/main/resources/yaml_change_value/with_comments_2_actual.yaml
@@ -52,11 +52,11 @@ spec:
 
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           #            requests:
           #              cpu: "100m"
           #              memory: "256Mi"

--- a/src/main/resources/yaml_change_value/with_comments_3_actual.yaml
+++ b/src/main/resources/yaml_change_value/with_comments_3_actual.yaml
@@ -52,11 +52,11 @@ spec:
 
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           #            requests:
           #              cpu: "100m"
           #              memory: "256Mi"

--- a/src/main/resources/yaml_change_value/with_comments_4_actual.yaml
+++ b/src/main/resources/yaml_change_value/with_comments_4_actual.yaml
@@ -52,11 +52,11 @@ spec:
 
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           #            requests:
           #              cpu: "100m"
           #              memory: "256Mi"

--- a/src/main/resources/yaml_change_value/with_comments_5_actual.yaml
+++ b/src/main/resources/yaml_change_value/with_comments_5_actual.yaml
@@ -52,11 +52,11 @@ spec:
 
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           #            requests:
           #              cpu: "100m"
           #              memory: "256Mi"

--- a/src/main/resources/yaml_change_value/with_comments_6_actual.yaml
+++ b/src/main/resources/yaml_change_value/with_comments_6_actual.yaml
@@ -52,11 +52,11 @@ spec:
 
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           #            requests:
           #              cpu: "100m"
           #              memory: "256Mi"

--- a/src/main/resources/yaml_change_value/with_comments_7_actual.yaml
+++ b/src/main/resources/yaml_change_value/with_comments_7_actual.yaml
@@ -52,11 +52,11 @@ spec:
 
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           #            requests:
           #              cpu: "100m"
           #              memory: "256Mi"

--- a/src/main/resources/yaml_change_value/with_comments_8_actual.yaml
+++ b/src/main/resources/yaml_change_value/with_comments_8_actual.yaml
@@ -52,11 +52,11 @@ spec:
 
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           #            requests:
           #              cpu: "100m"
           #              memory: "256Mi"

--- a/src/main/resources/yaml_change_value/with_comments_9_actual.yaml
+++ b/src/main/resources/yaml_change_value/with_comments_9_actual.yaml
@@ -52,11 +52,11 @@ spec:
 
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
-            limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
           #            requests:
           #              cpu: "100m"
           #              memory: "256Mi"

--- a/src/test/kotlin/dev/codemorph/benchmark/TestYamlChangeValue.kt
+++ b/src/test/kotlin/dev/codemorph/benchmark/TestYamlChangeValue.kt
@@ -5,6 +5,5 @@ import org.junit.jupiter.api.TestFactory
 
 class TestYamlChangeValue {
     @TestFactory
-    @Disabled
     fun testYamlChangeValue() = TestRunner.runCase("yaml_change_value")
 }


### PR DESCRIPTION
This PR contains the following modifications:

- Find & Replace: find "    @Disabled\n" replace with ""
- AI (openai/gpt-4.1-mini):
```
To ensure better stability and performance, it is proposed increasing the resource allocations to:

resources:
  requests:
    cpu: "500m"
    memory: "1Gi"
  limits:
    cpu: "2"
    memory: "2Gi"

Ignore lines that are commented out. 
Ignore files that are not yaml, keep them unchanged.
Do not create new files.
```
 (Single file: Yes)

Generated by [Morph](https://www.codemorph.dev).