### PR TITLE
Morph: switch to unleash for feature flags

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,9 @@ repositories {
 }
 
 dependencies {
-    implementation("io.github.java-diff-utils:java-diff-utils:4.15")
+    implementation("io.getunleash:unleash-client-java:10.2.2")
+
+    testImplementation("io.github.java-diff-utils:java-diff-utils:4.15")
     testImplementation(kotlin("test"))
 }
 

--- a/src/main/java/dev/codemorph/benchmark/unleash/FeatureFlags.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/FeatureFlags.java
@@ -1,0 +1,7 @@
+package dev.codemorph.benchmark.unleash;
+
+public class FeatureFlags {
+    public static boolean isFlagEnabled(String flag) {
+        return true;
+    }
+}

--- a/src/main/java/dev/codemorph/benchmark/unleash/TaskServiceActual.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/TaskServiceActual.java
@@ -1,0 +1,23 @@
+package dev.codemorph.benchmark.unleash;
+
+import java.util.List;
+import java.util.UUID;
+
+public class TaskServiceActual {
+
+    private final List<UUID> relevantTaskIds = List.of(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+
+    /**
+     * If feature relevant-tasks is enabled
+     *
+     * @return list of relevant task ids or otherwise an empty list
+     */
+    public List<UUID> getRelevantTaskIds() {
+        if (FeatureFlags.isFlagEnabled("relevant-tasks")) {
+            return relevantTaskIds;
+        } else {
+            return List.of();
+        }
+    }
+
+}

--- a/src/main/java/dev/codemorph/benchmark/unleash/TaskServiceActual.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/TaskServiceActual.java
@@ -3,9 +3,16 @@ package dev.codemorph.benchmark.unleash;
 import java.util.List;
 import java.util.UUID;
 
+import io.getunleash.Unleash;
+
 public class TaskServiceActual {
 
     private final List<UUID> relevantTaskIds = List.of(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+    private final Unleash unleash;
+
+    public TaskServiceActual(Unleash unleash) {
+        this.unleash = unleash;
+    }
 
     /**
      * If feature relevant-tasks is enabled
@@ -13,7 +20,7 @@ public class TaskServiceActual {
      * @return list of relevant task ids or otherwise an empty list
      */
     public List<UUID> getRelevantTaskIds() {
-        if (FeatureFlags.isFlagEnabled("relevant-tasks")) {
+        if (unleash.isEnabled("relevant-tasks")) {
             return relevantTaskIds;
         } else {
             return List.of();

--- a/src/main/java/dev/codemorph/benchmark/unleash/TaskServiceExpected.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/TaskServiceExpected.java
@@ -1,0 +1,30 @@
+package dev.codemorph.benchmark.unleash;
+
+import io.getunleash.Unleash;
+
+import java.util.List;
+import java.util.UUID;
+
+public class TaskServiceExpected {
+
+    private final Unleash unleash;
+
+    public TaskServiceExpected(Unleash unleash) {
+        this.unleash = unleash;
+    }
+
+    private final List<UUID> relevantTaskIds = List.of(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+
+    /**
+     * If feature relevant-tasks is enabled
+     *
+     * @return list of relevant task ids or otherwise an empty list
+     */
+    public List<UUID> getRelevantTaskIds() {
+        if (unleash.isEnabled("relevant-tasks")) {
+            return relevantTaskIds;
+        } else {
+            return List.of();
+        }
+    }
+}

--- a/src/test/java/dev/codemorph/benchmark/unleash/TaskServiceActualTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/TaskServiceActualTest.java
@@ -2,12 +2,16 @@ package dev.codemorph.benchmark.unleash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import io.getunleash.Unleash;
 
 class TaskServiceActualTest {
 
     @Test
     void getRelevantTaskIds() {
-        var instance = new TaskServiceActual();
+        Unleash unleash = Mockito.mock(Unleash.class);
+        Mockito.when(unleash.isEnabled("relevant-tasks")).thenReturn(true);
+        var instance = new TaskServiceActual(unleash);
 
         assertEquals(3, instance.getRelevantTaskIds().size());
     }

--- a/src/test/java/dev/codemorph/benchmark/unleash/TaskServiceActualTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/TaskServiceActualTest.java
@@ -1,0 +1,14 @@
+package dev.codemorph.benchmark.unleash;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+class TaskServiceActualTest {
+
+    @Test
+    void getRelevantTaskIds() {
+        var instance = new TaskServiceActual();
+
+        assertEquals(3, instance.getRelevantTaskIds().size());
+    }
+}


### PR DESCRIPTION
This PR contains the following modifications:

- AI (openai/gpt-4.1):
```
we are switching to unleash for checking feature flags. If FeatureFlags util is used make sure unleash instance is added to constructor (it will be injected automatically) and that unleash instance used instead to check whether feature flag is enabled. Also fix tests accordingly. Assume all feature flags are enabled in tests so you can mock unleash response to return true.

Unleash is a client in io.getunleash.Unleash package
```
 (Single file: No)

Generated by [Morph](https://www.codemorph.dev).