### PR TITLE
Morph: switch to unleash for feature flags

### DIFF
--- a/src/main/java/dev/codemorph/benchmark/unleash/TaskServiceActual.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/TaskServiceActual.java
@@ -2,8 +2,15 @@ package dev.codemorph.benchmark.unleash;
 
 import java.util.List;
 import java.util.UUID;
+import io.getunleash.Unleash;
 
 public class TaskServiceActual {
+
+    private final Unleash unleash;
+
+    public TaskServiceActual(Unleash unleash) {
+        this.unleash = unleash;
+    }
 
     private final List<UUID> relevantTaskIds = List.of(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
 
@@ -13,7 +20,7 @@ public class TaskServiceActual {
      * @return list of relevant task ids or otherwise an empty list
      */
     public List<UUID> getRelevantTaskIds() {
-        if (FeatureFlags.isFlagEnabled("relevant-tasks")) {
+        if (unleash.isEnabled("relevant-tasks")) {
             return relevantTaskIds;
         } else {
             return List.of();

--- a/src/test/java/dev/codemorph/benchmark/unleash/TaskServiceActualTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/TaskServiceActualTest.java
@@ -2,12 +2,16 @@ package dev.codemorph.benchmark.unleash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import io.getunleash.Unleash;
 
 class TaskServiceActualTest {
 
     @Test
     void getRelevantTaskIds() {
-        var instance = new TaskServiceActual();
+        var unleash = Mockito.mock(Unleash.class);
+        Mockito.when(unleash.isEnabled("relevant-tasks")).thenReturn(true);
+        var instance = new TaskServiceActual(unleash);
 
         assertEquals(3, instance.getRelevantTaskIds().size());
     }


### PR DESCRIPTION
This PR contains the following modifications:

- AI (openai/gpt-4.1):
```
we are switching to unleash for checking feature flags. If FeatureFlags util is used make sure unleash instance is added to constructor (it will be injected automatically) and that unleash instance used instead to check whether feature flag is enabled. Also fix tests accordingly. Assume all feature flags are enabled in tests so you can mock unleash response to return true.

Unleash is a client in io.getunleash.Unleash package
```
 (Single file: No)

Generated by [Morph](https://www.codemorph.dev).