### PR TITLE
Morph: switch to Unleash with Sonnet 4

### DIFF
--- a/src/main/java/dev/codemorph/benchmark/unleash/AnalyticsDailyJob.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/AnalyticsDailyJob.java
@@ -1,14 +1,20 @@
 package dev.codemorph.benchmark.unleash;
 
+import io.getunleash.Unleash;
 import java.util.*;
 
 public class AnalyticsDailyJob {
   private final List<String> reports = new ArrayList<>();
   private int stats = 0;
   private final String status = "READY";
+  private final Unleash unleash;
+
+  public AnalyticsDailyJob(Unleash unleash) {
+    this.unleash = unleash;
+  }
 
   public String runJob() {
-    if (FeatureFlags.isFlagEnabled("analytics-job-enabled")) {
+    if (unleash.isEnabled("analytics-job-enabled")) {
       logAnalytics("Job started");
       stats++;
       return "Job completed";
@@ -18,7 +24,7 @@ public class AnalyticsDailyJob {
   }
 
   public String getReport() {
-    if (FeatureFlags.isFlagEnabled("report-generation-enabled")) {
+    if (unleash.isEnabled("report-generation-enabled")) {
       String report = "Report: " + stats;
       reports.add(report);
       return report;
@@ -28,7 +34,7 @@ public class AnalyticsDailyJob {
   }
 
   public void logAnalytics(String message) {
-    if (FeatureFlags.isFlagEnabled("analytics-logging-enabled")) {
+    if (unleash.isEnabled("analytics-logging-enabled")) {
       reports.add(message);
     }
   }

--- a/src/main/java/dev/codemorph/benchmark/unleash/BillingService.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/BillingService.java
@@ -1,8 +1,16 @@
 package dev.codemorph.benchmark.unleash;
 
+import io.getunleash.Unleash;
+
 public class BillingService {
+  private final Unleash unleash;
+
+  public BillingService(Unleash unleash) {
+    this.unleash = unleash;
+  }
+
   public int getBillAmount() {
-    if (FeatureFlags.isFlagEnabled("billing-enabled")) {
+    if (unleash.isEnabled("billing-enabled")) {
       return 100;
     } else {
       return 0;

--- a/src/main/java/dev/codemorph/benchmark/unleash/BonusProgramManager.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/BonusProgramManager.java
@@ -1,14 +1,20 @@
 package dev.codemorph.benchmark.unleash;
 
+import io.getunleash.Unleash;
 import java.util.*;
 
 public class BonusProgramManager {
   private final Map<String, Integer> points = new HashMap<>();
   private final List<String> events = new ArrayList<>();
   private final String status = "ENABLED";
+  private final Unleash unleash;
+
+  public BonusProgramManager(Unleash unleash) {
+    this.unleash = unleash;
+  }
 
   public String activateBonus(String user) {
-    if (FeatureFlags.isFlagEnabled("bonus-activation-enabled")) {
+    if (unleash.isEnabled("bonus-activation-enabled")) {
       points.put(user, points.getOrDefault(user, 0) + 10);
       logBonusEvent("Activated bonus for: " + user);
       return "Bonus activated for: " + user;
@@ -18,7 +24,7 @@ public class BonusProgramManager {
   }
 
   public int getBonusPoints(String user) {
-    if (FeatureFlags.isFlagEnabled("bonus-points-check-enabled")) {
+    if (unleash.isEnabled("bonus-points-check-enabled")) {
       return points.getOrDefault(user, 0);
     } else {
       return -1;
@@ -26,7 +32,7 @@ public class BonusProgramManager {
   }
 
   public void logBonusEvent(String event) {
-    if (FeatureFlags.isFlagEnabled("bonus-logging-enabled")) {
+    if (unleash.isEnabled("bonus-logging-enabled")) {
       events.add(event);
     }
   }

--- a/src/main/java/dev/codemorph/benchmark/unleash/BranchingService.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/BranchingService.java
@@ -1,10 +1,18 @@
 package dev.codemorph.benchmark.unleash;
 
+import io.getunleash.Unleash;
+
 public class BranchingService {
+  private final Unleash unleash;
+
+  public BranchingService(Unleash unleash) {
+    this.unleash = unleash;
+  }
+
   public String getStatus(int x) {
-    if (FeatureFlags.isFlagEnabled("branching-enabled")) {
+    if (unleash.isEnabled("branching-enabled")) {
       if (x > 0) {
-        if (FeatureFlags.isFlagEnabled("positive-status")) {
+        if (unleash.isEnabled("positive-status")) {
           return "positive";
         } else {
           return "non-positive";

--- a/src/main/java/dev/codemorph/benchmark/unleash/CampaignManager.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/CampaignManager.java
@@ -1,14 +1,20 @@
 package dev.codemorph.benchmark.unleash;
 
+import io.getunleash.Unleash;
 import java.util.*;
 
 public class CampaignManager {
   private final Set<String> campaigns = new HashSet<>();
   private final List<String> logs = new ArrayList<>();
   private final String status = "READY";
+  private final Unleash unleash;
+
+  public CampaignManager(Unleash unleash) {
+    this.unleash = unleash;
+  }
 
   public String launchCampaign(String name) {
-    if (FeatureFlags.isFlagEnabled("campaign-launch-enabled")) {
+    if (unleash.isEnabled("campaign-launch-enabled")) {
       campaigns.add(name);
       logCampaignEvent("Launched: " + name);
       return "Campaign launched: " + name;
@@ -18,7 +24,7 @@ public class CampaignManager {
   }
 
   public String getCampaignStatus(String name) {
-    if (FeatureFlags.isFlagEnabled("campaign-status-check-enabled")) {
+    if (unleash.isEnabled("campaign-status-check-enabled")) {
       return campaigns.contains(name) ? "active" : "inactive";
     } else {
       return "Status check disabled";
@@ -26,7 +32,7 @@ public class CampaignManager {
   }
 
   public void logCampaignEvent(String event) {
-    if (FeatureFlags.isFlagEnabled("campaign-logging-enabled")) {
+    if (unleash.isEnabled("campaign-logging-enabled")) {
       logs.add(event);
     }
   }

--- a/src/main/java/dev/codemorph/benchmark/unleash/ComplexService.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/ComplexService.java
@@ -1,9 +1,18 @@
 package dev.codemorph.benchmark.unleash;
 
+import io.getunleash.Unleash;
+
 public class ComplexService {
+
+  private final Unleash unleash;
+
+  public ComplexService(Unleash unleash) {
+    this.unleash = unleash;
+  }
+
   public int compute(int a, int b) {
     int result = 0;
-    if (FeatureFlags.isFlagEnabled("complex-enabled")) {
+    if (unleash.isEnabled("complex-enabled")) {
       if (a > b) {
         result = a * 2;
       } else if (a == b) {

--- a/src/main/java/dev/codemorph/benchmark/unleash/CostCenterService.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/CostCenterService.java
@@ -1,14 +1,20 @@
 package dev.codemorph.benchmark.unleash;
 
+import io.getunleash.Unleash;
 import java.util.*;
 
 public class CostCenterService {
   private final Map<String, Double> centers = new HashMap<>();
   private final List<String> logs = new ArrayList<>();
   private final String status = "ACTIVE";
+  private final Unleash unleash;
+
+  public CostCenterService(Unleash unleash) {
+    this.unleash = unleash;
+  }
 
   public String addCostCenter(String name, double cost) {
-    if (FeatureFlags.isFlagEnabled("cost-center-add-enabled")) {
+    if (unleash.isEnabled("cost-center-add-enabled")) {
       centers.put(name, cost);
       logCostEvent("Added: " + name);
       return "Cost center added: " + name;
@@ -18,7 +24,7 @@ public class CostCenterService {
   }
 
   public double getCost(String name) {
-    if (FeatureFlags.isFlagEnabled("cost-check-enabled")) {
+    if (unleash.isEnabled("cost-check-enabled")) {
       return centers.getOrDefault(name, 0.0);
     } else {
       return -1.0;
@@ -26,7 +32,7 @@ public class CostCenterService {
   }
 
   public void logCostEvent(String event) {
-    if (FeatureFlags.isFlagEnabled("cost-logging-enabled")) {
+    if (unleash.isEnabled("cost-logging-enabled")) {
       logs.add(event);
     }
   }

--- a/src/main/java/dev/codemorph/benchmark/unleash/EventLogService.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/EventLogService.java
@@ -1,10 +1,17 @@
 package dev.codemorph.benchmark.unleash;
 
+import io.getunleash.Unleash;
 import java.util.List;
 
 public class EventLogService {
+  private final Unleash unleash;
+
+  public EventLogService(Unleash unleash) {
+    this.unleash = unleash;
+  }
+
   public List<String> getRecentEvents() {
-    if (FeatureFlags.isFlagEnabled("event-logging")) {
+    if (unleash.isEnabled("event-logging")) {
       return List.of("event1", "event2", "event3");
     } else {
       return List.of();

--- a/src/main/java/dev/codemorph/benchmark/unleash/InvitationHandler.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/InvitationHandler.java
@@ -1,14 +1,20 @@
 package dev.codemorph.benchmark.unleash;
 
+import io.getunleash.Unleash;
 import java.util.*;
 
 public class InvitationHandler {
   private final Set<String> pending = new HashSet<>();
   private final List<String> logs = new ArrayList<>();
   private final String status = "OPEN";
+  private final Unleash unleash;
+
+  public InvitationHandler(Unleash unleash) {
+    this.unleash = unleash;
+  }
 
   public String sendInvitation(String email) {
-    if (FeatureFlags.isFlagEnabled("invitation-send-enabled")) {
+    if (unleash.isEnabled("invitation-send-enabled")) {
       pending.add(email);
       logInvitation("Sent to: " + email);
       return "Invitation sent to: " + email;
@@ -18,7 +24,7 @@ public class InvitationHandler {
   }
 
   public String acceptInvitation(String email) {
-    if (FeatureFlags.isFlagEnabled("invitation-accept-enabled")) {
+    if (unleash.isEnabled("invitation-accept-enabled")) {
       pending.remove(email);
       logInvitation("Accepted by: " + email);
       return "Invitation accepted: " + email;
@@ -28,7 +34,7 @@ public class InvitationHandler {
   }
 
   public void logInvitation(String event) {
-    if (FeatureFlags.isFlagEnabled("invitation-logging-enabled")) {
+    if (unleash.isEnabled("invitation-logging-enabled")) {
       logs.add(event);
     }
   }

--- a/src/main/java/dev/codemorph/benchmark/unleash/LLMApiGateway.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/LLMApiGateway.java
@@ -1,19 +1,22 @@
 package dev.codemorph.benchmark.unleash;
 
+import io.getunleash.Unleash;
 import java.util.*;
 
 public class LLMApiGateway {
   private final Map<String, Integer> quota = new HashMap<>();
   private final List<String> logs = new ArrayList<>();
   private final String status = "OK";
+  private final Unleash unleash;
 
-  public LLMApiGateway() {
+  public LLMApiGateway(Unleash unleash) {
+    this.unleash = unleash;
     quota.put("user1", 100);
     quota.put("user2", 200);
   }
 
   public String callModel(String user, String prompt) {
-    if (FeatureFlags.isFlagEnabled("llm-call-enabled")) {
+    if (unleash.isEnabled("llm-call-enabled")) {
       logRequest(user, prompt);
       return "Response for: " + prompt;
     } else {
@@ -22,7 +25,7 @@ public class LLMApiGateway {
   }
 
   public int getQuota(String user) {
-    if (FeatureFlags.isFlagEnabled("quota-check-enabled")) {
+    if (unleash.isEnabled("quota-check-enabled")) {
       return quota.getOrDefault(user, 0);
     } else {
       return -1;
@@ -30,7 +33,7 @@ public class LLMApiGateway {
   }
 
   public void logRequest(String user, String prompt) {
-    if (FeatureFlags.isFlagEnabled("logging-enabled")) {
+    if (unleash.isEnabled("logging-enabled")) {
       logs.add(user + ": " + prompt);
     }
   }
@@ -48,7 +51,7 @@ public class LLMApiGateway {
   }
 
   public boolean isPremiumUser(String user) {
-    if (FeatureFlags.isFlagEnabled("premium-check-enabled")) {
+    if (unleash.isEnabled("premium-check-enabled")) {
       return user.startsWith("premium");
     } else {
       return false;

--- a/src/main/java/dev/codemorph/benchmark/unleash/MediaServiceGateway.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/MediaServiceGateway.java
@@ -1,8 +1,16 @@
 package dev.codemorph.benchmark.unleash;
 
+import io.getunleash.Unleash;
+
 public class MediaServiceGateway {
+  private final Unleash unleash;
+
+  public MediaServiceGateway(Unleash unleash) {
+    this.unleash = unleash;
+  }
+
   public String getMediaUrl() {
-    if (FeatureFlags.isFlagEnabled("media-service-enabled")) {
+    if (unleash.isEnabled("media-service-enabled")) {
       return "https://media.example.com/resource";
     } else {
       return null;

--- a/src/main/java/dev/codemorph/benchmark/unleash/NewsletterGenerationJob.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/NewsletterGenerationJob.java
@@ -1,8 +1,16 @@
 package dev.codemorph.benchmark.unleash;
 
+import io.getunleash.Unleash;
+
 public class NewsletterGenerationJob {
+  private final Unleash unleash;
+
+  public NewsletterGenerationJob(Unleash unleash) {
+    this.unleash = unleash;
+  }
+
   public String generateSummary() {
-    if (FeatureFlags.isFlagEnabled("newsletter-generation")) {
+    if (unleash.isEnabled("newsletter-generation")) {
       return "Newsletter summary generated.";
     } else {
       return null;

--- a/src/main/java/dev/codemorph/benchmark/unleash/NotificationManager.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/NotificationManager.java
@@ -1,8 +1,16 @@
 package dev.codemorph.benchmark.unleash;
 
+import io.getunleash.Unleash;
+
 public class NotificationManager {
+  private final Unleash unleash;
+
+  public NotificationManager(Unleash unleash) {
+    this.unleash = unleash;
+  }
+
   public String sendNotification(String user) {
-    if (FeatureFlags.isFlagEnabled("notifications-enabled")) {
+    if (unleash.isEnabled("notifications-enabled")) {
       return "Notification sent to " + user;
     } else {
       return null;

--- a/src/main/java/dev/codemorph/benchmark/unleash/PaymentGateway.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/PaymentGateway.java
@@ -1,7 +1,15 @@
 package dev.codemorph.benchmark.unleash;
 
+import io.getunleash.Unleash;
+
 public class PaymentGateway {
+  private final Unleash unleash;
+
+  public PaymentGateway(Unleash unleash) {
+    this.unleash = unleash;
+  }
+
   public boolean processPayment(double amount) {
-    return FeatureFlags.isFlagEnabled("payment-processing");
+    return unleash.isEnabled("payment-processing");
   }
 }

--- a/src/main/java/dev/codemorph/benchmark/unleash/ProjectWorkflowService.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/ProjectWorkflowService.java
@@ -1,14 +1,20 @@
 package dev.codemorph.benchmark.unleash;
 
+import io.getunleash.Unleash;
 import java.util.*;
 
 public class ProjectWorkflowService {
   private final List<String> actions = new ArrayList<>();
   private int projectCount = 0;
   private final String status = "IDLE";
+  private final Unleash unleash;
+
+  public ProjectWorkflowService(Unleash unleash) {
+    this.unleash = unleash;
+  }
 
   public String startProject(String name) {
-    if (FeatureFlags.isFlagEnabled("project-start-enabled")) {
+    if (unleash.isEnabled("project-start-enabled")) {
       logAction("Started project: " + name);
       projectCount++;
       return "Project started: " + name;
@@ -18,7 +24,7 @@ public class ProjectWorkflowService {
   }
 
   public String completeTask(String task) {
-    if (FeatureFlags.isFlagEnabled("task-complete-enabled")) {
+    if (unleash.isEnabled("task-complete-enabled")) {
       logAction("Completed task: " + task);
       return "Task completed: " + task;
     } else {
@@ -27,7 +33,7 @@ public class ProjectWorkflowService {
   }
 
   public void logAction(String action) {
-    if (FeatureFlags.isFlagEnabled("workflow-logging-enabled")) {
+    if (unleash.isEnabled("workflow-logging-enabled")) {
       actions.add(action);
     }
   }

--- a/src/main/java/dev/codemorph/benchmark/unleash/StorageManager.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/StorageManager.java
@@ -1,8 +1,16 @@
 package dev.codemorph.benchmark.unleash;
 
+import io.getunleash.Unleash;
+
 public class StorageManager {
+  private final Unleash unleash;
+
+  public StorageManager(Unleash unleash) {
+    this.unleash = unleash;
+  }
+
   public int getStoredFileCount() {
-    if (FeatureFlags.isFlagEnabled("storage-enabled")) {
+    if (unleash.isEnabled("storage-enabled")) {
       return 5;
     } else {
       return 0;

--- a/src/main/java/dev/codemorph/benchmark/unleash/SubscriptionService.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/SubscriptionService.java
@@ -1,8 +1,16 @@
 package dev.codemorph.benchmark.unleash;
 
+import io.getunleash.Unleash;
+
 public class SubscriptionService {
+  private final Unleash unleash;
+
+  public SubscriptionService(Unleash unleash) {
+    this.unleash = unleash;
+  }
+
   public String getSubscriptionStatus() {
-    if (FeatureFlags.isFlagEnabled("subscription-active")) {
+    if (unleash.isEnabled("subscription-active")) {
       return "active";
     } else {
       return "inactive";

--- a/src/main/java/dev/codemorph/benchmark/unleash/TaskServiceActual.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/TaskServiceActual.java
@@ -1,5 +1,6 @@
 package dev.codemorph.benchmark.unleash;
 
+import io.getunleash.Unleash;
 import java.util.List;
 import java.util.UUID;
 
@@ -7,6 +8,7 @@ public class TaskServiceActual {
 
   private final List<UUID> relevantTaskIds =
       List.of(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+  private final Unleash unleash;
 
   /**
    * If feature relevant-tasks is enabled

--- a/src/main/java/dev/codemorph/benchmark/unleash/TranslationManager.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/TranslationManager.java
@@ -1,8 +1,16 @@
 package dev.codemorph.benchmark.unleash;
 
+import io.getunleash.Unleash;
+
 public class TranslationManager {
+  private final Unleash unleash;
+
+  public TranslationManager(Unleash unleash) {
+    this.unleash = unleash;
+  }
+
   public String translate(String input) {
-    if (FeatureFlags.isFlagEnabled("translation-enabled")) {
+    if (unleash.isEnabled("translation-enabled")) {
       return "[translated] " + input;
     } else {
       return input;

--- a/src/main/java/dev/codemorph/benchmark/unleash/UserLifecycleService.java
+++ b/src/main/java/dev/codemorph/benchmark/unleash/UserLifecycleService.java
@@ -1,14 +1,20 @@
 package dev.codemorph.benchmark.unleash;
 
+import io.getunleash.Unleash;
 import java.util.*;
 
 public class UserLifecycleService {
   private final Set<String> users = new HashSet<>();
   private final List<String> events = new ArrayList<>();
   private final String status = "ACTIVE";
+  private final Unleash unleash;
+
+  public UserLifecycleService(Unleash unleash) {
+    this.unleash = unleash;
+  }
 
   public String registerUser(String user) {
-    if (FeatureFlags.isFlagEnabled("user-registration-enabled")) {
+    if (unleash.isEnabled("user-registration-enabled")) {
       users.add(user);
       logLifecycleEvent("Registered: " + user);
       return "User registered: " + user;
@@ -18,7 +24,7 @@ public class UserLifecycleService {
   }
 
   public String deactivateUser(String user) {
-    if (FeatureFlags.isFlagEnabled("user-deactivation-enabled")) {
+    if (unleash.isEnabled("user-deactivation-enabled")) {
       users.remove(user);
       logLifecycleEvent("Deactivated: " + user);
       return "User deactivated: " + user;
@@ -28,7 +34,7 @@ public class UserLifecycleService {
   }
 
   public void logLifecycleEvent(String event) {
-    if (FeatureFlags.isFlagEnabled("lifecycle-logging-enabled")) {
+    if (unleash.isEnabled("lifecycle-logging-enabled")) {
       events.add(event);
     }
   }

--- a/src/test/java/dev/codemorph/benchmark/unleash/AnalyticsDailyJobTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/AnalyticsDailyJobTest.java
@@ -1,13 +1,17 @@
 package dev.codemorph.benchmark.unleash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
 
+import io.getunleash.Unleash;
 import org.junit.jupiter.api.Test;
 
 class AnalyticsDailyJobTest {
   @Test
   void runJob() {
-    var instance = new AnalyticsDailyJob();
+    Unleash unleash = mock(Unleash.class);
+    when(unleash.isEnabled(anyString())).thenReturn(true);
+    var instance = new AnalyticsDailyJob(unleash);
     assertEquals("Job completed", instance.runJob());
   }
 }

--- a/src/test/java/dev/codemorph/benchmark/unleash/BillingServiceTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/BillingServiceTest.java
@@ -1,13 +1,17 @@
 package dev.codemorph.benchmark.unleash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
 
+import io.getunleash.Unleash;
 import org.junit.jupiter.api.Test;
 
 class BillingServiceTest {
   @Test
   void getBillAmount() {
-    var instance = new BillingService();
+    Unleash unleash = mock(Unleash.class);
+    when(unleash.isEnabled("billing-enabled")).thenReturn(true);
+    var instance = new BillingService(unleash);
     assertEquals(100, instance.getBillAmount());
   }
 }

--- a/src/test/java/dev/codemorph/benchmark/unleash/BonusProgramManagerTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/BonusProgramManagerTest.java
@@ -1,13 +1,17 @@
 package dev.codemorph.benchmark.unleash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
 
+import io.getunleash.Unleash;
 import org.junit.jupiter.api.Test;
 
 class BonusProgramManagerTest {
   @Test
   void activateBonus() {
-    var instance = new BonusProgramManager();
+    Unleash unleash = mock(Unleash.class);
+    when(unleash.isEnabled(anyString())).thenReturn(true);
+    var instance = new BonusProgramManager(unleash);
     assertEquals("Bonus activated for: Carol", instance.activateBonus("Carol"));
   }
 }

--- a/src/test/java/dev/codemorph/benchmark/unleash/BranchingServiceTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/BranchingServiceTest.java
@@ -2,12 +2,16 @@ package dev.codemorph.benchmark.unleash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.getunleash.Unleash;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class BranchingServiceTest {
   @Test
   void getStatus() {
-    var instance = new BranchingService();
+    var unleash = Mockito.mock(Unleash.class);
+    Mockito.when(unleash.isEnabled(Mockito.anyString())).thenReturn(true);
+    var instance = new BranchingService(unleash);
     assertEquals("positive", instance.getStatus(1));
   }
 }

--- a/src/test/java/dev/codemorph/benchmark/unleash/CampaignManagerTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/CampaignManagerTest.java
@@ -2,12 +2,16 @@ package dev.codemorph.benchmark.unleash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.getunleash.Unleash;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class CampaignManagerTest {
   @Test
   void launchCampaign() {
-    var instance = new CampaignManager();
+    Unleash unleash = Mockito.mock(Unleash.class);
+    Mockito.when(unleash.isEnabled(Mockito.anyString())).thenReturn(true);
+    var instance = new CampaignManager(unleash);
     assertEquals("Campaign launched: Spring", instance.launchCampaign("Spring"));
   }
 }

--- a/src/test/java/dev/codemorph/benchmark/unleash/ComplexServiceTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/ComplexServiceTest.java
@@ -1,13 +1,17 @@
 package dev.codemorph.benchmark.unleash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
 
+import io.getunleash.Unleash;
 import org.junit.jupiter.api.Test;
 
 class ComplexServiceTest {
   @Test
   void compute() {
-    var instance = new ComplexService();
+    Unleash unleash = mock(Unleash.class);
+    when(unleash.isEnabled("complex-enabled")).thenReturn(true);
+    var instance = new ComplexService(unleash);
     assertEquals(6, instance.compute(3, 2));
   }
 }

--- a/src/test/java/dev/codemorph/benchmark/unleash/CostCenterServiceTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/CostCenterServiceTest.java
@@ -1,13 +1,17 @@
 package dev.codemorph.benchmark.unleash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
 
+import io.getunleash.Unleash;
 import org.junit.jupiter.api.Test;
 
 class CostCenterServiceTest {
   @Test
   void addCostCenter() {
-    var instance = new CostCenterService();
+    Unleash unleash = mock(Unleash.class);
+    when(unleash.isEnabled(anyString())).thenReturn(true);
+    var instance = new CostCenterService(unleash);
     assertEquals("Cost center added: IT", instance.addCostCenter("IT", 1000.0));
   }
 }

--- a/src/test/java/dev/codemorph/benchmark/unleash/EventLogServiceTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/EventLogServiceTest.java
@@ -1,13 +1,17 @@
 package dev.codemorph.benchmark.unleash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
 
+import io.getunleash.Unleash;
 import org.junit.jupiter.api.Test;
 
 class EventLogServiceTest {
   @Test
   void getRecentEvents() {
-    var instance = new EventLogService();
+    Unleash unleash = mock(Unleash.class);
+    when(unleash.isEnabled("event-logging")).thenReturn(true);
+    var instance = new EventLogService(unleash);
     assertEquals(3, instance.getRecentEvents().size());
   }
 }

--- a/src/test/java/dev/codemorph/benchmark/unleash/InvitationHandlerTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/InvitationHandlerTest.java
@@ -1,13 +1,17 @@
 package dev.codemorph.benchmark.unleash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
 
+import io.getunleash.Unleash;
 import org.junit.jupiter.api.Test;
 
 class InvitationHandlerTest {
   @Test
   void sendInvitation() {
-    var instance = new InvitationHandler();
+    Unleash unleash = mock(Unleash.class);
+    when(unleash.isEnabled(anyString())).thenReturn(true);
+    var instance = new InvitationHandler(unleash);
     assertEquals(
         "Invitation sent to: test@example.com", instance.sendInvitation("test@example.com"));
   }

--- a/src/test/java/dev/codemorph/benchmark/unleash/LLMApiGatewayTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/LLMApiGatewayTest.java
@@ -2,12 +2,16 @@ package dev.codemorph.benchmark.unleash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.getunleash.Unleash;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class LLMApiGatewayTest {
   @Test
   void callModel() {
-    var instance = new LLMApiGateway();
+    var unleash = Mockito.mock(Unleash.class);
+    Mockito.when(unleash.isEnabled(Mockito.anyString())).thenReturn(true);
+    var instance = new LLMApiGateway(unleash);
     assertEquals("Response for: test", instance.callModel("user1", "test"));
   }
 }

--- a/src/test/java/dev/codemorph/benchmark/unleash/MediaServiceGatewayTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/MediaServiceGatewayTest.java
@@ -1,13 +1,17 @@
 package dev.codemorph.benchmark.unleash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
 
+import io.getunleash.Unleash;
 import org.junit.jupiter.api.Test;
 
 class MediaServiceGatewayTest {
   @Test
   void getMediaUrl() {
-    var instance = new MediaServiceGateway();
+    Unleash mockUnleash = mock(Unleash.class);
+    when(mockUnleash.isEnabled("media-service-enabled")).thenReturn(true);
+    var instance = new MediaServiceGateway(mockUnleash);
     assertEquals("https://media.example.com/resource", instance.getMediaUrl());
   }
 }

--- a/src/test/java/dev/codemorph/benchmark/unleash/NewsletterGenerationJobTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/NewsletterGenerationJobTest.java
@@ -1,13 +1,17 @@
 package dev.codemorph.benchmark.unleash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
 
+import io.getunleash.Unleash;
 import org.junit.jupiter.api.Test;
 
 class NewsletterGenerationJobTest {
   @Test
   void generateSummary() {
-    var instance = new NewsletterGenerationJob();
+    Unleash unleash = mock(Unleash.class);
+    when(unleash.isEnabled("newsletter-generation")).thenReturn(true);
+    var instance = new NewsletterGenerationJob(unleash);
     assertEquals("Newsletter summary generated.", instance.generateSummary());
   }
 }

--- a/src/test/java/dev/codemorph/benchmark/unleash/NotificationManagerTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/NotificationManagerTest.java
@@ -2,12 +2,16 @@ package dev.codemorph.benchmark.unleash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.getunleash.Unleash;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class NotificationManagerTest {
   @Test
   void sendNotification() {
-    var instance = new NotificationManager();
+    Unleash unleash = Mockito.mock(Unleash.class);
+    Mockito.when(unleash.isEnabled("notifications-enabled")).thenReturn(true);
+    var instance = new NotificationManager(unleash);
     assertEquals("Notification sent to Alice", instance.sendNotification("Alice"));
   }
 }

--- a/src/test/java/dev/codemorph/benchmark/unleash/PaymentGatewayTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/PaymentGatewayTest.java
@@ -2,12 +2,16 @@ package dev.codemorph.benchmark.unleash;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.getunleash.Unleash;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class PaymentGatewayTest {
   @Test
   void processPayment() {
-    var instance = new PaymentGateway();
+    Unleash unleash = Mockito.mock(Unleash.class);
+    Mockito.when(unleash.isEnabled("payment-processing")).thenReturn(true);
+    var instance = new PaymentGateway(unleash);
     assertTrue(instance.processPayment(42.0));
   }
 }

--- a/src/test/java/dev/codemorph/benchmark/unleash/ProjectWorkflowServiceTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/ProjectWorkflowServiceTest.java
@@ -1,13 +1,17 @@
 package dev.codemorph.benchmark.unleash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
 
+import io.getunleash.Unleash;
 import org.junit.jupiter.api.Test;
 
 class ProjectWorkflowServiceTest {
   @Test
   void startProject() {
-    var instance = new ProjectWorkflowService();
+    Unleash unleash = mock(Unleash.class);
+    when(unleash.isEnabled(anyString())).thenReturn(true);
+    var instance = new ProjectWorkflowService(unleash);
     assertEquals("Project started: Alpha", instance.startProject("Alpha"));
   }
 }

--- a/src/test/java/dev/codemorph/benchmark/unleash/StorageManagerTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/StorageManagerTest.java
@@ -1,13 +1,17 @@
 package dev.codemorph.benchmark.unleash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
 
+import io.getunleash.Unleash;
 import org.junit.jupiter.api.Test;
 
 class StorageManagerTest {
   @Test
   void getStoredFileCount() {
-    var instance = new StorageManager();
+    Unleash unleash = mock(Unleash.class);
+    when(unleash.isEnabled("storage-enabled")).thenReturn(true);
+    var instance = new StorageManager(unleash);
     assertEquals(5, instance.getStoredFileCount());
   }
 }

--- a/src/test/java/dev/codemorph/benchmark/unleash/SubscriptionServiceTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/SubscriptionServiceTest.java
@@ -1,13 +1,17 @@
 package dev.codemorph.benchmark.unleash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
 
+import io.getunleash.Unleash;
 import org.junit.jupiter.api.Test;
 
 class SubscriptionServiceTest {
   @Test
   void getSubscriptionStatus() {
-    var instance = new SubscriptionService();
+    Unleash unleash = mock(Unleash.class);
+    when(unleash.isEnabled("subscription-active")).thenReturn(true);
+    var instance = new SubscriptionService(unleash);
     assertEquals("active", instance.getSubscriptionStatus());
   }
 }

--- a/src/test/java/dev/codemorph/benchmark/unleash/TaskServiceActualTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/TaskServiceActualTest.java
@@ -1,14 +1,18 @@
 package dev.codemorph.benchmark.unleash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
 
+import io.getunleash.Unleash;
 import org.junit.jupiter.api.Test;
 
 class TaskServiceActualTest {
 
   @Test
   void getRelevantTaskIds() {
-    var instance = new TaskServiceActual();
+    Unleash unleash = mock(Unleash.class);
+    when(unleash.isEnabled("relevant-tasks")).thenReturn(true);
+    var instance = new TaskServiceActual(unleash);
 
     assertEquals(3, instance.getRelevantTaskIds().size());
   }

--- a/src/test/java/dev/codemorph/benchmark/unleash/TranslationManagerTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/TranslationManagerTest.java
@@ -1,13 +1,17 @@
 package dev.codemorph.benchmark.unleash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
 
+import io.getunleash.Unleash;
 import org.junit.jupiter.api.Test;
 
 class TranslationManagerTest {
   @Test
   void translate() {
-    var instance = new TranslationManager();
+    Unleash unleash = mock(Unleash.class);
+    when(unleash.isEnabled("translation-enabled")).thenReturn(true);
+    var instance = new TranslationManager(unleash);
     assertEquals("[translated] foo", instance.translate("foo"));
   }
 }

--- a/src/test/java/dev/codemorph/benchmark/unleash/UserLifecycleServiceTest.java
+++ b/src/test/java/dev/codemorph/benchmark/unleash/UserLifecycleServiceTest.java
@@ -1,13 +1,17 @@
 package dev.codemorph.benchmark.unleash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
 
+import io.getunleash.Unleash;
 import org.junit.jupiter.api.Test;
 
 class UserLifecycleServiceTest {
   @Test
   void registerUser() {
-    var instance = new UserLifecycleService();
+    Unleash unleash = mock(Unleash.class);
+    when(unleash.isEnabled(anyString())).thenReturn(true);
+    var instance = new UserLifecycleService(unleash);
     assertEquals("User registered: Bob", instance.registerUser("Bob"));
   }
 }


### PR DESCRIPTION
This PR contains the following modifications:

- AI (anthropic/claude-sonnet-4-20250514):
```
we are switching to unleash for checking feature flags. If FeatureFlags util is used make sure unleash instance is added to constructor (it will be injected automatically) and that unleash instance used instead to check whether feature flag is enabled. Also fix tests accordingly. Assume all feature flags are enabled in tests so you can mock unleash response to return true.

Unleash is a client in io.getunleash.Unleash package
Make sure necessary imports are present

Use google java format style.
New class fields should be added to the end of existing fields. 

** Important ** Do not create any new files.
```
 (Slicing enabled: Yes)

Generated by [Morph](https://codemorph.dev)